### PR TITLE
cql-exeuction has been updated to support evaluatedResources for mult…

### DIFF
--- a/lib/cypress/fqm_execution_calc.rb
+++ b/lib/cypress/fqm_execution_calc.rb
@@ -16,17 +16,13 @@ module Cypress
 
     def execute(save = true)
       results = @measures.map do |measure|
-        @patients.map do |patient|
-          request_for(measure, patient, save)
-        end.flatten
+        request_for(measure, save)
       end.flatten
       results
     end
 
-    # TODO: The fqm-execution-service seems to have issues when passing in multiple patients
-    # After this is fixed, we can go back to using @patients.map(&:patient_bundle_hash) instead of passing in a single patient
-    def request_for(measure, patient, _save = true)
-      post_data = { patients: [patient.patient_bundle_hash], measure: measure.measure_bundle_hash, options: @options }
+    def request_for(measure, _save = true)
+      post_data = { patients: @patients.map(&:patient_bundle_hash), measure: measure.measure_bundle_hash, options: @options }
       post_data = post_data.to_json(methods: %i[_type])
       begin
         response = RestClient::Request.execute(method: :post, url: self.class.create_connection_string, timeout: 120,


### PR DESCRIPTION
…iple patients

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code